### PR TITLE
v0.6.0

### DIFF
--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuelrats/eslint-config-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ESLint config for our react projects",
   "author": {
     "name": "Cameron Welter",

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuelrats/eslint-config",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ESLint config for fuelrats projects",
   "author": {
     "name": "Cameron Welter",

--- a/eslint-config/rules/bestpractices.js
+++ b/eslint-config/rules/bestpractices.js
@@ -341,7 +341,7 @@ module.exports = {
 
 
     // require parentheses around immediate function invocations
-    'wrap-iife': ['error', 'outside', {
+    'wrap-iife': ['error', 'inside', {
       functionPrototypeMethods: false,
     }],
 

--- a/eslint-config/rules/plugin-babel.js
+++ b/eslint-config/rules/plugin-babel.js
@@ -10,10 +10,11 @@ module.exports = {
       capIsNew: true,
       newIsCapExceptions: [],
       capIsNewExceptions: [
-        'GET',
+        'GET', // For HTTP methods
         'POST',
         'PUT',
         'DELETE',
+        'Stripe', // For Stripe lib (which exists as window.Stripe)
       ],
       properties: true,
     }],

--- a/eslint-config/rules/style.js
+++ b/eslint-config/rules/style.js
@@ -132,15 +132,15 @@ module.exports = {
       outerIIFEBody: 1,
       MemberExpression: 1,
       FunctionDeclaration: {
-        parameters: 'first',
+        parameters: 1,
         body: 1,
       },
       FunctionExpression: {
-        parameters: 'first',
+        parameters: 1,
         body: 1,
       },
       CallExpression: {
-        arguments: 'first',
+        arguments: 1,
       },
       ArrayExpression: 1,
       ObjectExpression: 1,
@@ -352,7 +352,7 @@ module.exports = {
       },
       {
         selector: 'LabeledStatement',
-        message: 'Labels are like GOTOs, they make your code less readable for little benefit. ',
+        message: 'Labels are like GOTOs, they make your code less readable for little benefit.',
       },
       {
         selector: 'BinaryExpression[operator=\'in\']',


### PR DESCRIPTION
* Prefer IIFEs to be inner wrapped `(function () { ... })()` instead of outer wrapped `(function () { ... }())`
* Add `Stripe` as a new-cap exception
* Prefer a single level indentation for multi-line function parameters (this should have been removed before initial release)