### PR TITLE
V2.1.0 adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fuelrats",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "Monorepo for @fuelrats/eslint-config[-react]!",
   "private": true,
   "license": "MIT",

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -5,11 +5,22 @@
 
 
 
+### 2.1.0
+
+#### Changes
+* Disable `react/no-did-mount-set-state` due to it's lack of exceptions for async data handling.
+* Disable `jsx-a11y/no-onchange` due to some false positives we were seeing.
+
+#### Fixed
+* Remove `react-dom` as a peer dependency.
+
+
+
 
 
 ### 2.0.0
 
-- Initial release intended for general consumption
+* Initial release intended for general consumption
 
 
 

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuelrats/eslint-config-react",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "ESLint config for fuelrats react projects",
   "license": "MIT",
   "author": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -64,7 +64,6 @@
     "eslint-plugin-jsx-a11y": ">=6.2",
     "eslint-plugin-react": ">=7.18",
     "eslint-plugin-react-hooks": ">=2.3",
-    "react": ">=16.8",
-    "react-dom": ">=16.8"
+    "react": ">=16.8"
   }
 }

--- a/packages/eslint-config-react/rules/plugin-jsx-a11y.js
+++ b/packages/eslint-config-react/rules/plugin-jsx-a11y.js
@@ -216,7 +216,7 @@ module.exports = {
     /**
      * Enforce usage of onBlur over onChange on select menus for accessibility.
      */
-    'jsx-a11y/no-onchange': ['error'],
+    'jsx-a11y/no-onchange': ['off'],
 
 
     /**

--- a/packages/eslint-config-react/rules/plugin-react.js
+++ b/packages/eslint-config-react/rules/plugin-react.js
@@ -123,8 +123,10 @@ module.exports = {
 
     /**
      * Prevent usage of `setState` in `componentDidMount`
+     *
+     * _DISABLED: This rule needs an exception for `async componentDidMount()` before we can use it._
      */
-    'react/no-did-mount-set-state': ['error'],
+    'react/no-did-mount-set-state': ['off'],
 
 
     /**

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -5,11 +5,19 @@
 
 
 
+### 2.1.0
+
+#### Changes
+* re-enable `import/no-cycle` due to the problems cyclic dependencies cause in most environments.
+* enable `no-undef`'s `typeof` rule. If you are `typeof` checking a global unknown to eslint, you should define it!
+
+
+
 
 
 ### 2.0.0
 
-- Initial release intended for general consumption
+* Initial release intended for general consumption
 
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuelrats/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "ESLint config for fuelrats projects",
   "license": "MIT",
   "author": {

--- a/packages/eslint-config/rules/plugin-import.js
+++ b/packages/eslint-config/rules/plugin-import.js
@@ -94,10 +94,10 @@ module.exports = {
 
     /**
      * Forbid a module from importing a module with a dependency path back to itself
-     *
-     * _DISABLED: Our environments do not have an issue with cyclic loading._
      */
-    'import/no-cycle': ['off'],
+    'import/no-cycle': ['error', {
+      maxDepth: Infinity,
+    }],
 
 
     /**

--- a/packages/eslint-config/rules/variables.js
+++ b/packages/eslint-config/rules/variables.js
@@ -41,7 +41,9 @@ module.exports = {
     /**
      * disallow the use of undeclared variables unless mentioned in `global` comments
      */
-    'no-undef': ['error'],
+    'no-undef': ['error', {
+      typeof: true,
+    }],
 
 
     /**


### PR DESCRIPTION
### Base
* re-enable `import/no-cycle`. Given how problematic cyclic dependencies can be in a in the majority of ESModule-based environments, we should check for it in the majority of our code, and only make exceptions where we have tested it to be okay to do so.
* Enable `no-undef`'s `typeof` checking. This forces identifiers being checked with `typeof` to be defined. This will only have an impact on type checking global variables for their existence, however all global variables should be defined for ESLint anyway.


### React
* disable `react/no-did-mount-set-state`. I would like to have this rule enabled, but since it lacks an exception for async data loading, we cannot recommend it as a rule.
* disable `jsx-a11y/no-onchange`. we use onChange pretty extensively, and this rule errors in places where it makes little sense to do so.
* remove `react-dom` from `eslint-config-react`'s peer dependencies. 


@xlexi This is stuff I've identified as a problem while migrating to v2. Let me know if we need to adjust anything else while we're at it.